### PR TITLE
chore: update anthropic SDK version constraint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
-anthropic>=0.24.0
+# Anthropic Python SDK for Claude API
+# Pinned to recent stable version for reproducible builds
+# Review periodically: https://github.com/anthropics/anthropic-sdk-python/releases
+anthropic>=0.70.0,<1.0.0
 


### PR DESCRIPTION
- Raise minimum version from 0.24.0 to 0.70.0 (52 versions behind)
- Add upper bound <1.0.0 to prevent major version breaking changes
- Add documentation comments for maintenance guidance
- No security vulnerabilities found in dependency audit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns dependency to a recent stable Anthropic SDK and guards against breaking major updates.
> 
> - Updates `requirements.txt` to `anthropic>=0.70.0,<1.0.0` (was `>=0.24.0`)
> - Adds documentation comments for version pinning and review guidance
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4557afb8acfcb63aa156d6d33831073a3a9d01e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->